### PR TITLE
fix: Get-A-Head/frontend-flutter/issues/196 , Support local screen share

### DIFF
--- a/.idea/inspectionProfiles/ktlint.xml
+++ b/.idea/inspectionProfiles/ktlint.xml
@@ -3,5 +3,10 @@
     <option name="myName" value="ktlint" />
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="RedundantSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
   </profile>
 </component>

--- a/programmable_video/lib/src/local_video_track.dart
+++ b/programmable_video/lib/src/local_video_track.dart
@@ -50,11 +50,11 @@ class LocalVideoTrack extends VideoTrack {
   ///
   /// By default the widget will be mirrored, to change that set [mirror] to false.
   /// If you provide a [key] make sure it is unique among all [VideoTrack]s otherwise Flutter might send the wrong creation params to the native side.
-  Widget widget({String videoTrackSid = '', bool mirror = true, Key? key}) {
+  Widget widget({bool isScreenShare = false, bool mirror = true, Key? key}) {
     key ??= ValueKey('Twilio_LocalParticipant');
 
     return ProgrammableVideoPlatform.instance.createLocalVideoTrackWidget(
-      videoTrackSid: videoTrackSid,
+      isScreenShare: isScreenShare,
       mirror: mirror,
       key: key,
     );

--- a/programmable_video/lib/src/programmable_video.dart
+++ b/programmable_video/lib/src/programmable_video.dart
@@ -89,7 +89,7 @@ class TwilioProgrammableVideo {
   /// [Exception] : screen share _**failed**_ or is _**not supported by the browser**_
   ///
   /// This function uses the Twilio Programmable Video SDK to [publish a track](https://media.twiliocdn.com/sdk/js/video/releases/2.13.1/docs/LocalParticipant.html#publishTrack__anchor)
-  static Future<bool?> startScreenShare() async {
+  static Future<Widget?> startScreenShare() async {
     return ProgrammableVideoPlatform.instance.startScreenShare();
   }
 

--- a/programmable_video/test/mock_platform_interface.dart
+++ b/programmable_video/test/mock_platform_interface.dart
@@ -25,7 +25,7 @@ class MockInterface extends ProgrammableVideoPlatform {
   var disconnectWasCalled = false;
 
   @override
-  Widget createLocalVideoTrackWidget({String videoTrackSid = '', bool mirror = true, Key? key}) {
+  Widget createLocalVideoTrackWidget({bool isScreenShare = false, bool mirror = true, Key? key}) {
     key ??= ValueKey('Twilio_LocalParticipant');
     return Container(key: key);
   }

--- a/programmable_video_platform_interface/lib/src/method_channel_programmable_video.dart
+++ b/programmable_video_platform_interface/lib/src/method_channel_programmable_video.dart
@@ -64,7 +64,7 @@ class MethodChannelProgrammableVideo extends ProgrammableVideoPlatform {
   //#region Functions
   /// Calls native code to create a widget displaying the LocalVideoTrack's video.
   @override
-  Widget createLocalVideoTrackWidget({String videoTrackSid = '', bool mirror = true, Key? key}) {
+  Widget createLocalVideoTrackWidget({bool isScreenShare = false, bool mirror = true, Key? key}) {
     key ??= ValueKey('Twilio_LocalParticipant');
 
     final creationParams = {

--- a/programmable_video_platform_interface/lib/src/programmable_video_platform_interface.dart
+++ b/programmable_video_platform_interface/lib/src/programmable_video_platform_interface.dart
@@ -43,7 +43,7 @@ abstract class ProgrammableVideoPlatform extends PlatformInterface {
 
   //#region Functions
   /// Calls native code to create a widget displaying the LocalVideoTrack's video.
-  Widget createLocalVideoTrackWidget({String videoTrackSid = '', bool mirror = true, Key? key}) {
+  Widget createLocalVideoTrackWidget({bool isScreenShare = false, bool mirror = true, Key? key}) {
     throw UnimplementedError('createLocalVideoTrackWidget() has not been implemented.');
   }
 
@@ -149,7 +149,7 @@ abstract class ProgrammableVideoPlatform extends PlatformInterface {
   /// [Exception] : screen share _**failed**_ or is _**not supported by the browser**_
   ///
   /// This function uses the Twilio Programmable Video SDK to [publish a track](https://media.twiliocdn.com/sdk/js/video/releases/2.13.1/docs/LocalParticipant.html#publishTrack__anchor)
-  Future<bool?> startScreenShare() {
+  Future<Widget?> startScreenShare() {
     throw UnimplementedError('startScreenShare() has not been implemented.');
   }
 

--- a/programmable_video_web/lib/src/listeners/local_participant_event_listener.dart
+++ b/programmable_video_web/lib/src/listeners/local_participant_event_listener.dart
@@ -67,7 +67,7 @@ class LocalParticipantEventListener extends BaseListener {
           (publication as LocalVideoTrackPublication).toModel(),
         ));
         if (_localParticipant.videoTracks.toDartMap()[publication.trackSid] != null) {
-          debug('Remote participant >> Adding missing video track to remote participants video track list');
+          debug('Remote participant >> Adding video track publication to remote participant video track list');
           _localParticipant.videoTracks.toDartMap()[publication.trackSid] = publication;
         }
       },


### PR DESCRIPTION
Now the `startScreenShare()` function returns the `HtmlView` as a `Widget`